### PR TITLE
Compat grafter 0.8.x

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,8 +4,7 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [grafter/grafter "0.8.3-SNAPSHOT"]
-                 [grafter/vocabularies "0.2.0-SNAPSHOT"]
+                 [grafter/grafter "0.8.6"]
                  [selmer "1.0.4"]]
   :deploy-repositories [["releases" :clojars]
                         ["snapshots" :clojars]])

--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [grafter/grafter "0.8.6"]
+                 [grafter/grafter "0.8.7"]
                  [selmer "1.0.4"]]
   :deploy-repositories [["releases" :clojars]
                         ["snapshots" :clojars]])

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject grafter/extra "0.1.5-grafter080-SNAPSHOT"
+(defproject grafter/extra "0.2.0-SNAPSHOT"
   :description "A collection of extra transformations and tools for developing Grafter pipelines"
   :url "http://grafter.org/"
   :license {:name "Eclipse Public License"


### PR DESCRIPTION
@Robsteranium I've bumped this to use 0.8.7 of grafter and would like to finalise this as a 0.2.0 release `lein release` (to indicate more than a patch revision) and bump to latest grafter 0.8.7 - so we can lock other builds.

I'm happy for it to be merged and `lein release`'d if you are, basically just checking you're happy for this to happen.

Some downstream deps are waiting for this to be locked to `0.2.0`